### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.1",
-        "guzzlehttp/guzzle": "^7.0"
+        "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",


### PR DESCRIPTION
Optimistic attempt to make Elastic Transport compatible with Guzzle 6...

To give a little bit of context, I'm trying to use https://github.com/elastic/enterprise-search-php (from a Drupal module) which requires elastic/transport, which itself requires Guzzle 7.

However Drupal 8 & 9 are still stuck on Guzzle 6. 

Not 100% sure about the other changes required though.