### PR TITLE
Allow `psr/log` v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2|^3",
         "php-http/discovery": "^1.14",
         "php-http/httplug": "^2.3"
     },


### PR DESCRIPTION
@ezimuel Could you have a look at this? I don't understand why `elasticsearch-php` supports v2+v3 while this dependency  does not. 