### PR TITLE
Encode user info when setting it

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -199,11 +199,13 @@ final class Transport implements ClientInterface, HttpAsyncClient
     private function setupUserInfo(RequestInterface $request): RequestInterface
     {
         $uri = $request->getUri();
-        $encodedUser = urlencode($this->user);
-        $encodedPassword = urlencode($this->password);
         if (empty($uri->getUserInfo())) {
             if (isset($this->user)) {
-                $request = $request->withUri($uri->withUserInfo($encodedUser, $encodedPassword));
+                if (isset($this->password)) {
+                    $request = $request->withUri($uri->withUserInfo(urlencode($this->user), urlencode($this->password)));
+                } else {
+                    $request = $request->withUri($uri->withUserInfo(urlencode($this->user)));
+                }
             }
         }
         return $request;

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -199,9 +199,11 @@ final class Transport implements ClientInterface, HttpAsyncClient
     private function setupUserInfo(RequestInterface $request): RequestInterface
     {
         $uri = $request->getUri();
+        $encodedUser = urlencode($this->user);
+        $encodedPassword = urlencode($this->password);
         if (empty($uri->getUserInfo())) {
             if (isset($this->user)) {
-                $request = $request->withUri($uri->withUserInfo($this->user, $this->password));
+                $request = $request->withUri($uri->withUserInfo($encodedUser, $encodedPassword));
             }
         }
         return $request;


### PR DESCRIPTION
This will urlencode user info (username & password) before setting them.

This will make sure passwords with special characters like '@' not cause
problems.

fixes
[https://github.com/elastic/elasticsearch-php/issues/1232](https://github.com/elastic/elasticsearch-php/issues/1232#)