### PR TITLE
Log full message bodies

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -233,7 +233,7 @@ final class Transport implements ClientInterface, HttpAsyncClient
         $this->logger->debug(sprintf(
             "Headers: %s\nBody: %s",
             json_encode($message->getHeaders()),
-            $message->getBody()->getContents()
+            (string) $message->getBody()
         ));
     }
 

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -27,6 +27,7 @@ use Http\Client\HttpAsyncClient;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Mock\Client;
 use Http\Promise\Promise;
+use Nyholm\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -258,20 +259,20 @@ final class TransportTest extends TestCase
         $this->nodePool->method('nextNode')
             ->willReturn($this->node);
 
-        $request = $this->requestFactory->createRequest('GET', '/');
+        $request = new Request('GET', '/', ['X-Baz' => 'qux'], "Hi");
         $this->transport->sendRequest($request);
 
         $this->assertTrue($this->logger->hasInfo([
             'message' => "Request: GET http://localhost/"
         ]));
         $this->assertTrue($this->logger->hasDebug([
-            'message' => "Headers: {\"Host\":[\"localhost\"]}\nBody: "
+            'message' => "Headers: {\"Host\":[\"localhost\"],\"X-Baz\":[\"qux\"]}\nBody: Hi"
         ]));
         $this->assertTrue($this->logger->hasInfo([
             'message' => sprintf("Response (retry 0): %s", $statusCode),
         ]));
         $this->assertTrue($this->logger->hasDebug([
-            'message' => "Headers: {\"X-Foo\":[\"Bar\"]}\nBody: "
+            'message' => "Headers: {\"X-Foo\":[\"Bar\"]}\nBody: " . $msg
         ]));
     }
 


### PR DESCRIPTION
Use the `_toString()` method when sending the request and response body to the logger in order to guarantee that the full message is logged. At the time when the messages are logged the body stream pointer is already at the end so calls to `getContents()` return an empty string