### PR TITLE
Add full request and response to the log message context

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -244,7 +244,9 @@ final class Transport implements ClientInterface, HttpAsyncClient
             $title,
             $request->getMethod(),
             (string) $request->getUri()
-        ));
+        ), [
+            'request' => $request
+        ]);
         $this->logHeaders($request);
     }
 
@@ -255,7 +257,10 @@ final class Transport implements ClientInterface, HttpAsyncClient
             $title,
             $retry, 
             $response->getStatusCode()
-        ));
+        ), [
+            'response' => $response,
+            'retry' => $retry
+        ]);
         $this->logHeaders($response);
     }
 


### PR DESCRIPTION
Hey, this PR adds the request and response objects to the context of the log messages logged by the Transport class. This allows us to build more powerful log handlers with the ability to pull any info from the request and response objects instead of just using the predefined log message.

What is this good for? For example I've used this to build an integration with [Clockwork](https://underground.works/clockwork/) that allows me to interactively inspect the request and response content.

<img width="1608" alt="Screenshot 2022-10-30 at 22 52 28" src="https://user-images.githubusercontent.com/821582/198903341-2addc7f8-aad5-4f10-b93b-b8a366736d53.png">
