### PR TITLE
[add/path-to-connection-uri] Update Transport.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 8.7.0 (2023-05-23)
+
+- Allow installation of psr/http-message v2.0
+  [#17](https://github.com/elastic/elastic-transport-php/pull/17)
+
+## 8.6.0 (2023-01-12)
+
+- Add full request and response to the log message context for better integration using [Clockwork](https://underground.works/clockwork/)
+  [#13](https://github.com/elastic/elastic-transport-php/pull/13)
+
 ## 8.5.0 (2022-10-14)
 
 - Release created to be compatible with 8.5 Elastic clients

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.4 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "^1 || ^2 || ^3",
         "php-http/discovery": "^1.14",
         "php-http/httplug": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
         "phpstan": [
             "vendor/bin/phpstan analyse"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 parameters:
-    level: max
+    level: 8
+    checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
     treatPhpDocTypesAsCertain: false
     paths:

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -219,6 +219,7 @@ final class Transport implements ClientInterface, HttpAsyncClient
                 ->withHost($uri->getHost())
                 ->withPort($uri->getPort())
                 ->withScheme($uri->getScheme())
+                ->withPath($uri->getPath())
         );
     }
 

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -48,7 +48,7 @@ use function strtolower;
 
 final class Transport implements ClientInterface, HttpAsyncClient
 {
-    const VERSION = "8.6.0";
+    const VERSION = "8.7.0";
 
     private ClientInterface $client;
     private LoggerInterface $logger;
@@ -448,8 +448,8 @@ final class Transport implements ClientInterface, HttpAsyncClient
     private function getClientLibraryInfo(): array
     {
         $clientClass = get_class($this->client);
-        if (false !== strpos($clientClass, 'GuzzleHttp\\Client')) {
-            return ['gu', InstalledVersions::getPrettyVersion('guzzlehttp/guzzle')];
+        if (false !== strpos($clientClass, 'GuzzleHttp\Client')) {
+            return ['gu', InstalledVersions::getPrettyVersion('guzzlehttp/guzzle')]; 
         }
         if (false !== strpos($clientClass, 'Symfony\Component\HttpClient')) {
             return ['sy', InstalledVersions::getPrettyVersion('symfony/http-client')];

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -100,17 +100,17 @@ final class TransportTest extends TestCase
 
     public function testSendRequestWithUriThatContainsAPath()
     {
-        $url = 'http://localhost/subfolder/';
+        $url = 'http://localhost/subfolder';
         $expectedResponse = $this->responseFactory->createResponse(200);
         $this->client->addResponse($expectedResponse);
 
         $this->node->method('getUri')->willReturn($this->uriFactory->createUri($url));
         $this->nodePool->method('nextNode')->willReturn($this->node);
 
-        $request = $this->requestFactory->createRequest('GET', '/');
+        $request = $this->requestFactory->createRequest('GET', '/test');
         $response = $this->transport->sendRequest($request);
 
-        $this->assertEquals($url, (string) $this->client->getLastRequest()->getUri());
+        $this->assertEquals($url . '/test', (string) $this->client->getLastRequest()->getUri());
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals($expectedResponse, $response);
     }

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -98,6 +98,23 @@ final class TransportTest extends TestCase
         $this->assertEquals($expectedResponse, $response);
     }
 
+    public function testSendRequestWithUriThatContainsAPath()
+    {
+        $url = 'http://localhost/subfolder/';
+        $expectedResponse = $this->responseFactory->createResponse(200);
+        $this->client->addResponse($expectedResponse);
+
+        $this->node->method('getUri')->willReturn($this->uriFactory->createUri($url));
+        $this->nodePool->method('nextNode')->willReturn($this->node);
+
+        $request = $this->requestFactory->createRequest('GET', '/');
+        $response = $this->transport->sendRequest($request);
+
+        $this->assertEquals($url, (string) $this->client->getLastRequest()->getUri());
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals($expectedResponse, $response);
+    }
+
     public function testSendRequestWithNetworkException()
     {
         $request = $this->requestFactory->createRequest('GET', '/');


### PR DESCRIPTION
Add the path, which could be configured in the hosts, to the request uri.

 See https://github.com/elastic/elasticsearch-php/issues/1377 for more details.

_Please note that there isn't a 8.7 branch on this repository while there is a 8.7. release._

