### PR TITLE
Added support for Open Telemetry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,16 @@
         "psr/log": "^1 || ^2 || ^3",
         "php-http/discovery": "^1.14",
         "php-http/httplug": "^2.3",
-        "composer-runtime-api": "^2.0"
+        "composer-runtime-api": "^2.0",
+        "open-telemetry/api": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.4",
         "php-http/mock-client": "^1.5",
-        "nyholm/psr7": "^1.5"
+        "nyholm/psr7": "^1.5",
+        "open-telemetry/sdk": "^1.0",
+        "symfony/http-client": "^7.1"
     },
     "autoload": {
         "psr-4": {
@@ -39,7 +42,7 @@
     },
     "scripts": {
         "test": [
-            "vendor/bin/phpunit"
+            "vendor/bin/phpunit --testdox"
         ],
         "phpstan": [
             "vendor/bin/phpstan analyse"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php-http/mock-client": "^1.5",
         "nyholm/psr7": "^1.5",
         "open-telemetry/sdk": "^1.0",
-        "symfony/http-client": "^7.1"
+        "symfony/http-client": "^5.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/OpenTelemetry.php
+++ b/src/OpenTelemetry.php
@@ -39,18 +39,6 @@ class OpenTelemetry
      */
     const ENV_VARIABLE_BODY_SANITIZE_KEYS = 'OTEL_PHP_INSTRUMENTATION_ELASTICSEARCH_SEARCH_QUERY_SANITIZE_KEYS';
 
-    const SEARCH_ENDPOINTS = [
-        'search',
-        'async_search.submit',
-        'msearch',
-        'eql.search',
-        'terms_enum',
-        'search_template',
-        'msearch_template',
-        'render_search_template',
-        'esql.query'
-    ];
-
     const DEFAULT_SANITIZER_KEY_PATTERNS = [
         'password',
         'passwd',

--- a/src/OpenTelemetry.php
+++ b/src/OpenTelemetry.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Elastic Transport
+ *
+ * @link      https://github.com/elastic/elastic-transport-php
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   https://opensource.org/licenses/MIT MIT License
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the MIT License.
+ * See the LICENSE file in the project root for more information.
+ */
+declare(strict_types=1);
+
+namespace Elastic\Transport;
+
+use Elastic\Transport\Exception\InvalidArgumentException;
+use Elastic\Transport\Serializer\JsonSerializer;
+use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+
+class OpenTelemetry
+{
+    const OTEL_TRACER_NAME = 'elasticsearch-api';
+    // Valid values for the enabled config are 'true' and 'false'
+    const ENV_VARIABLE_ENABLED = 'OTEL_PHP_INSTRUMENTATION_ELASTICSEARCH_ENABLED';
+    /**
+     * Describes how to handle search queries in the request body when assigned to
+     * span attribute.
+     * Valid values are 'raw', 'omit', 'sanitize'. Default is 'omit'
+     */
+    const ALLOWED_BODY_STRATEGIES = ['raw', 'omit', 'sanitize'];
+    const ENV_VARIABLE_BODY_STRATEGY = 'OTEL_PHP_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY';
+    const DEFAULT_BODY_STRATEGY = 'omit';
+    /**
+     * A string list of keys whose values are redacted. This is only relevant if the body strategy is
+     * 'sanitize'. For example, a config 'sensitive-key,other-key' will redact the values at
+     * 'sensitive-key' and 'other-key' in addition to the default keys
+     */
+    const ENV_VARIABLE_BODY_SANITIZE_KEYS = 'OTEL_PHP_INSTRUMENTATION_ELASTICSEARCH_SEARCH_QUERY_SANITIZE_KEYS';
+
+    const SEARCH_ENDPOINTS = [
+        'search',
+        'async_search.submit',
+        'msearch',
+        'eql.search',
+        'terms_enum',
+        'search_template',
+        'msearch_template',
+        'render_search_template',
+        'esql.query'
+    ];
+
+    const DEFAULT_SANITIZER_KEY_PATTERNS = [
+        'password',
+        'passwd',
+        'pwd',
+        'secret',
+        'key',
+        'token',
+        'session',
+        'credit',
+        'card',
+        'auth',
+        'set-cookie',
+        'email',
+        'tel',
+        'phone'
+    ];
+    const REDACTED_STRING = 'REDACTED';
+
+    private array $sanitizeKeys = [];
+    private string $bodyStrategy;
+
+    public function __construct()
+    {
+        $strategy = getenv(self::ENV_VARIABLE_BODY_STRATEGY);
+        if (false === $strategy) {
+            $strategy = self::DEFAULT_BODY_STRATEGY;
+        }
+        if (!in_array($strategy, self::ALLOWED_BODY_STRATEGIES)) {
+            throw new InvalidArgumentException(sprintf(
+                'The body strategy specified %s is not valid. The available strategies are %s',
+                $strategy,
+                implode(',', self::ALLOWED_BODY_STRATEGIES)
+            ));
+        }
+        $this->bodyStrategy = $strategy;
+        $sanitizeKeys = getenv(self::ENV_VARIABLE_BODY_SANITIZE_KEYS);
+        if (false !== $sanitizeKeys) {
+            $this->sanitizeKeys = explode(',', $sanitizeKeys);
+        }
+    }
+
+    public function processBody(string $body): string
+    {
+        switch ($this->bodyStrategy) {
+            case 'sanitize':
+                return $this->sanitizeBody($body, $this->sanitizeKeys);
+            case 'raw':
+                return $body;
+            default:
+                return '';
+        }
+    }
+    
+    public static function getTracer(TracerProviderInterface $tracerProvider): TracerInterface
+    {
+        return $tracerProvider->getTracer(
+            self::OTEL_TRACER_NAME,
+            Transport::VERSION
+        );
+    }
+
+    private function sanitizeBody(string $body, array $sanitizeKeys): string
+    {
+        if (empty($body)) {
+            return '';
+        }
+        $json = json_decode($body, true);
+        if (!is_array($json)) {
+            return '';
+        }
+        $patterns = array_merge(self::DEFAULT_SANITIZER_KEY_PATTERNS, $sanitizeKeys);
+
+        // Convert the patterns array into a regex
+        $regex = sprintf('/%s/', implode('|', $patterns));
+        // Recursively traverse the array and redact the specified keys
+        array_walk_recursive($json, function (&$value, $key) use ($regex) {
+            if (preg_match($regex, $key, $matches)) {
+                $value = self::REDACTED_STRING;
+            }
+        });
+        return JsonSerializer::serialize($json);
+    }
+}

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -28,6 +28,8 @@ use Exception;
 use Http\Client\HttpAsyncClient;
 use Http\Discovery\HttpAsyncClientDiscovery;
 use Http\Promise\Promise;
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Trace\TracerInterface;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
@@ -48,7 +50,7 @@ use function strtolower;
 
 final class Transport implements ClientInterface, HttpAsyncClient
 {
-    const VERSION = "8.8.0";
+    const VERSION = "8.9.0";
 
     private ClientInterface $client;
     private LoggerInterface $logger;
@@ -63,7 +65,8 @@ final class Transport implements ClientInterface, HttpAsyncClient
     private HttpAsyncClient $asyncClient;
     private OnSuccessInterface $onAsyncSuccess;
     private OnFailureInterface $onAsyncFailure;
-
+    private TracerInterface $otelTracer;
+    
     public function __construct(
         ClientInterface $client,
         NodePoolInterface $nodePool,
@@ -87,6 +90,22 @@ final class Transport implements ClientInterface, HttpAsyncClient
     public function getLogger(): LoggerInterface
     {
         return $this->logger;
+    }
+
+    public function getOTelTracer(): TracerInterface
+    {
+        if (empty($this->otelTracer)) {
+            $this->otelTracer = OpenTelemetry::getTracer(
+                Globals::tracerProvider()
+            );
+        }
+        return $this->otelTracer;
+    }
+
+    public function setOTelTracer(TracerInterface $tracer): self
+    {
+        $this->otelTracer = $tracer;
+        return $this;
     }
 
     public function setHeader(string $name, string $value): self
@@ -285,7 +304,7 @@ final class Transport implements ClientInterface, HttpAsyncClient
      * @throws NoNodeAvailableException
      * @throws ClientExceptionInterface
      */
-    public function sendRequest(RequestInterface $request): ResponseInterface
+    public function sendRequest(RequestInterface $request, array $opts = []): ResponseInterface
     {   
         if (empty($request->getUri()->getHost())) {
             $node = $this->nodePool->nextNode();
@@ -294,11 +313,27 @@ final class Transport implements ClientInterface, HttpAsyncClient
         $request = $this->decorateRequest($request);
         $this->lastRequest = $request;
         $this->logRequest("Request", $request);
+
+        // OpenTelemetry get tracer
+        if (getenv(OpenTelemetry::ENV_VARIABLE_ENABLED)) {
+            $tracer = $this->getOTelTracer();
+        }
         
         $count = -1;
         while ($count < $this->getRetries()) {
             try {
                 $count++;
+                // OpenTelemetry span start
+                if (!empty($tracer)) {
+                    $spanName = $opts['db.operation.name'] ?? $request->getUri()->getPath();
+                    $span = $tracer->spanBuilder($spanName)->startSpan();
+                    $span->setAttribute('http.request.method', $request->getMethod());
+                    $span->setAttribute('url.full', $this->getFullUrl($request));
+                    $span->setAttribute('server.address', $request->getUri()->getHost());
+                    $span->setAttribute('server.port', $request->getUri()->getPort());
+                    // @phpstan-ignore argument.type
+                    $span->setAttributes($opts);
+                }
                 $response = $this->client->sendRequest($request);
 
                 $this->lastResponse = $response;
@@ -307,6 +342,9 @@ final class Transport implements ClientInterface, HttpAsyncClient
                 return $response;
             } catch (NetworkExceptionInterface $e) {
                 $this->logger->error(sprintf("Retry %d: %s", $count, $e->getMessage()));
+                if (!empty($span)) {
+                    $span->setAttribute('error.type', $e->getMessage());
+                }
                 if (isset($node)) {
                     $node->markAlive(false);
                     $node = $this->nodePool->nextNode();
@@ -314,7 +352,15 @@ final class Transport implements ClientInterface, HttpAsyncClient
                 }
             } catch (ClientExceptionInterface $e) {
                 $this->logger->error(sprintf("Retry %d: %s", $count, $e->getMessage()));
+                if (!empty($span)) {
+                    $span->setAttribute('error.type', $e->getMessage());
+                }
                 throw $e;
+            } finally {
+                 // OpenTelemetry span end
+                if (!empty($span)) {
+                    $span->end();
+                }
             }
         }
         $exceededMsg = sprintf("Exceeded maximum number of retries (%d)", $this->getRetries());
@@ -463,5 +509,25 @@ final class Transport implements ClientInterface, HttpAsyncClient
             return ['sy', InstalledVersions::getPrettyVersion('symfony/http-client')];
         }
         return [];
+    }
+
+    /**
+     * Return the full URL in the format
+     * scheme://host:port/path?query_string
+     */
+    private function getFullUrl(RequestInterface $request): string
+    {
+        $fullUrl = sprintf(
+            "%s://%s:%s%s", 
+            $request->getUri()->getScheme(),
+            $request->getUri()->getHost(),
+            $request->getUri()->getPort(),
+            $request->getUri()->getPath()
+        );
+        $queryString = $request->getUri()->getQuery();
+        if (!empty($queryString)) {
+            $fullUrl .= '?' . $queryString;
+        }
+        return $fullUrl;
     }
 }

--- a/src/TransportBuilder.php
+++ b/src/TransportBuilder.php
@@ -20,6 +20,7 @@ use Elastic\Transport\Exception;
 use Elastic\Transport\NodePool\Resurrect\NoResurrect;
 use Elastic\Transport\NodePool\Selector\RoundRobin;
 use Http\Discovery\Psr18ClientDiscovery;
+use OpenTelemetry\API\Trace\TracerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -31,6 +32,7 @@ class TransportBuilder
     protected NodePoolInterface $nodePool;
     protected LoggerInterface $logger;
     protected array $hosts = [];
+    protected TracerInterface $OTelTracer;
 
     final public function __construct()
     {

--- a/tests/OpenTelemetryTest.php
+++ b/tests/OpenTelemetryTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Elastic Transport
+ *
+ * @link      https://github.com/elastic/elastic-transport-php
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   https://opensource.org/licenses/MIT MIT License
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the MIT License.
+ * See the LICENSE file in the project root for more information.
+ */
+declare(strict_types=1);
+
+namespace Elastic\Transport\Test;
+
+use Elastic\Transport\Exception\InvalidArgumentException;
+use Elastic\Transport\OpenTelemetry;
+use PHPUnit\Framework\TestCase;
+
+final class OpenTelemetryTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        // Remove env variables
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_STRATEGY);
+    }
+
+    public function testConstructWithNoParams()
+    {
+        $otel = new OpenTelemetry();
+        $this->assertInstanceOf(OpenTelemetry::class, $otel);
+    }
+
+    public function testConstructWithEnvBodyStrategy()
+    {
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_STRATEGY . '=sanitize');
+        $otel = new OpenTelemetry();
+        $this->assertInstanceOf(OpenTelemetry::class, $otel);
+    }
+
+    public function testConstructWithInvalidEnvBodyStrategy()
+    {
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_STRATEGY . '=foo');
+        $this->expectException(InvalidArgumentException::class);
+        $otel = new OpenTelemetry();
+    }
+
+    public function testProcessBodyWithDefault()
+    {
+        $body = '{"password":"supersecret"}';
+        $otel = new OpenTelemetry();
+        // Default is omit, it should returns an empty string
+        $this->assertEmpty($otel->processBody($body, 'search'));
+    }
+
+    public function testProcessBodyWithRaw()
+    {
+        $body = '{"password":"supersecret"}';
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_STRATEGY . '=raw');
+        $otel = new OpenTelemetry();
+        // Default is omit, it should returns an empty string
+        $this->assertEquals($body, $otel->processBody($body, 'search'));
+    }
+
+    public function testProcessBodyWithSanitize()
+    {
+        $body = '{"password":"supersecret"}';
+        $sanitizeBody = sprintf('{"password":"%s"}', OpenTelemetry::REDACTED_STRING);
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_STRATEGY . '=sanitize');
+        $otel = new OpenTelemetry();
+        // Default is omit, it should returns an empty string
+        $this->assertEquals($sanitizeBody, $otel->processBody($body));
+    }
+
+    public function testProcessBodyWithSanitizeUsingRegex()
+    {
+        $body = '{"secret_key":"supersecret"}';
+        $sanitizeBody = sprintf('{"secret_key":"%s"}', OpenTelemetry::REDACTED_STRING);
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_STRATEGY . '=sanitize');
+        $otel = new OpenTelemetry();
+        // Default is omit, it should returns an empty string
+        $this->assertEquals($sanitizeBody, $otel->processBody($body));
+    }
+
+    public function testProcessBodyWithSanitizeUsingCustomRegex()
+    {
+        $body = '{"foo_bar":"supersecret"}';
+        $sanitizeBody = sprintf('{"foo_bar":"%s"}', OpenTelemetry::REDACTED_STRING);
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_SANITIZE_KEYS . '=bar');
+        putenv(OpenTelemetry::ENV_VARIABLE_BODY_STRATEGY . '=sanitize');
+        $otel = new OpenTelemetry();
+        // Default is omit, it should returns an empty string
+        $this->assertEquals($sanitizeBody, $otel->processBody($body));
+    }
+}


### PR DESCRIPTION
Following the guideline reported [here](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/elasticsearch.md), I added the support for Open Telemetry in `Transport::sendRequest()` function. 

This PR adds an `elasticsearch-api` tracer using the `Globals::tracerProvider()` of the [Open Telemetry API for PHP](https://opentelemetry.io/docs/languages/php/getting-started/#add-manual-instrumentation).
In the `Transport::sendRequest()` I created a span with the following attributes:
```
http.request.method
url.full
server.address
server.port
```
I also added an optional parameter to the `Transport::sendRequest()` function as follows:
```php
public function sendRequest(RequestInterface $request, array $opts = []): ResponseInterface
```
The `$opts` array contains additional OTel attributes that can be passed at runtime. This array will be used to fullfill the specific Elasticsearch OTel attributes like:
```
db.operation.name
db.elasticsearch.path_parts.<key>
db.query.text
```
The complete list of Elasticsearch attributes is reported [here](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/elasticsearch.md).

This PR solves #24 