### PR TITLE
fix: missing response body with guzzle psr7 streams

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -272,6 +272,8 @@ final class Transport implements ClientInterface, HttpAsyncClient
             json_encode($message->getHeaders()),
             (string) $message->getBody()
         ));
+
+        $message->getBody()->rewind();
     }
 
     private function logRequest(string $title, RequestInterface $request): void


### PR DESCRIPTION
Because you cast the body to string, it triggers https://github.com/guzzle/psr7/blob/2.7/src/Stream.php#L84

and therefore the Guzzle Stream has been read to the end, and a getContents afterwards always returns an empty string