### PR TITLE
fixes PHP (7.4+) errors - "must not be accessed before initialization" in getLastRequest() & getLastResponse()

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -59,8 +59,8 @@ final class Transport implements ClientInterface, HttpAsyncClient
     private array $headers = [];
     private string $user;
     private string $password;
-    private RequestInterface $lastRequest;
-    private ResponseInterface $lastResponse;
+    private ?RequestInterface $lastRequest = null;
+    private ?ResponseInterface $lastResponse = null;
     private string $OSVersion;
     private int $retries = 0;
     private HttpAsyncClient $asyncClient;
@@ -190,12 +190,12 @@ final class Transport implements ClientInterface, HttpAsyncClient
         return str_replace(['alpha', 'beta', 'snapshot', 'rc', 'pre'], 'p', strtolower($version)); 
     }
 
-    public function getLastRequest(): RequestInterface
+    public function getLastRequest(): ?RequestInterface
     {
         return $this->lastRequest;
     }
 
-    public function getLastResponse(): ResponseInterface
+    public function getLastResponse(): ?ResponseInterface
     {
         return $this->lastResponse;
     }


### PR DESCRIPTION
1. When getLastResponse is called after the request has failed (exception was thrown)
Elastic\Transport\Transport::$lastResponse must not be accessed before initialization

2. When getLastRequest is called before any request
Elastic\Transport\Transport::$lastRequest must not be accessed before initialization


