### PR TITLE
feat: add Node::getLastPing and Node::getFailedPings for custom NodePool implementations with ping backoffs

### DIFF
--- a/src/NodePool/Node.php
+++ b/src/NodePool/Node.php
@@ -24,6 +24,8 @@ class Node
 {
     protected UriInterface $uri;
     protected bool $alive = true;
+    protected int $failedPings = 0;
+    protected ?int $lastPing = null; // timestamp
 
     public function __construct(string $host)
     {
@@ -36,6 +38,8 @@ class Node
     public function markAlive(bool $alive): void
     {
         $this->alive = $alive;
+        $this->failedPings = $alive ? 0 : ($this->failedPings + 1);
+        $this->lastPing = time();
     }
 
     public function isAlive(): bool
@@ -46,5 +50,15 @@ class Node
     public function getUri(): UriInterface
     {
         return $this->uri;
+    }
+
+    public function getLastPing(): int
+    {
+        return $this->lastPing;
+    }
+
+    public function getFailedPings(): int
+    {
+        return $this->failedPings;
     }
 }


### PR DESCRIPTION
After migration from [elasticsearch/elasticsearch](https://packagist.org/packages/elasticsearch/elasticsearch) version 7 to version 8, this functionality was missing.
Currently using a workaround where these properties are added using extended class, but that requires custom Node class, custom NodePool class, and custom Selector classes.
If these props were at least in the base library, that would help a lot.