### PR TITLE
Handle package not found exception when installed vendor prefixed

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -520,10 +520,18 @@ final class Transport implements ClientInterface, HttpAsyncClient
     {
         $clientClass = get_class($this->client);
         if (false !== strpos($clientClass, 'GuzzleHttp\Client')) {
-            return ['gu', InstalledVersions::getPrettyVersion('guzzlehttp/guzzle')]; 
+            try {
+                return ['gu', InstalledVersions::getPrettyVersion('guzzlehttp/guzzle')];
+            } catch (\OutOfBoundsException $e) {
+                return [];
+            }
         }
         if (false !== strpos($clientClass, 'Symfony\Component\HttpClient')) {
-            return ['sy', InstalledVersions::getPrettyVersion('symfony/http-client')];
+            try {
+                return ['sy', InstalledVersions::getPrettyVersion('symfony/http-client')];
+            } catch (\OutOfBoundsException $e) {
+                return [];
+            }
         }
         return [];
     }


### PR DESCRIPTION
I tried to use the ElasticSearch client in a WordPress plugin that uses vendor prefixing. In the case of vendor prefixing, the `elastic/transport` code is patched to prefix namespaces.

Apparently a situation may occur where the line

```php
if (false !== strpos($clientClass, 'GuzzleHttp\Client')) {
```

matches the namespace of a prefixed Guzzle client, while the line

```php
return ['gu', InstalledVersions::getPrettyVersion('guzzlehttp/guzzle')];
```

attempts to find a non-prefixed version. When it is not found, Composer throws an `OutOfBoundsException`.

I don't know how to get the Guzzle version in a way that is compatible with prefixing, but at least this change will handle the situation gracefully.